### PR TITLE
nobug: replace go-get with go-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Command `taggit` is a git repository workflow tool for publishing semver release
 The `oss.indeed.com/go/taggit` CLI tool can be installed by running:
 
 ```bash
-$ go get oss.indeed.com/go/taggit
+$ go install oss.indeed.com/go/taggit@latest
 ```
 
 Example usage:


### PR DESCRIPTION
Newer versions of Go will no longer install commands using `go get`, but rather `go install`; fix README instructions. 